### PR TITLE
Implement allow all tracing for OPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,28 @@ gem "trailblazer-pro-rails"
 
 Note: we're currently playing with various invocation styles and at some point you might not even have to use `Operation.wtf?` anymore.
 
+## Configuration (optional)
 
+Configure your operations to use the web debugger, example configuration:
+```ruby
+# config/environments/development.rb
+config.trailblazer.pro.trace_operations = {
+  "API::V1::Diagram::Operation::Update" => true,
+  "API::V1::Diagram::Operation::Create" => true,
+}
+```
+
+Or, if you want to trace all operations, use `:all` as the value.
+```ruby
+# config/environments/development.rb
+config.trailblazer.pro.trace_operations = :all
+```
+
+Disable printing trace to console, show only link to web debugger.
+```ruby
+# config/environments/development.rb
+  config.trailblazer.pro.render_wtf = false
+```
 
 ## Testing
 

--- a/lib/trailblazer/pro/rails/railtie.rb
+++ b/lib/trailblazer/pro/rails/railtie.rb
@@ -9,8 +9,6 @@ module Trailblazer
         # load session and set Pro::Session.session
         initializer "trailblazer-pro-rails.load_session_and_extend_operation" do
           config.after_initialize do
-            Trailblazer::Operation.extend(Pro::Operation::WTF)  # TODO: only apply to selected OPs or make at least configurable?
-
             config_options = {
               render_wtf: config.trailblazer.pro.render_wtf,
             }
@@ -24,15 +22,17 @@ module Trailblazer
               trace_operations = config.trailblazer.pro.trace_operations
 
               if trace_operations
-                # constants can be passed as strings to avoid autoloading issues.
-                trace_operations = trace_operations.collect { |klass, config| [klass.constantize, config] }.to_h
+                if trace_operations.is_a?(Hash)
+                  # constants can be passed as strings to avoid autoloading issues.
+                  trace_operations = trace_operations.collect { |klass, config| [klass.constantize, config] }.to_h
+                end
 
                 Pro.trace_operations!(trace_operations)
               end
 
               # TODO: add {Activity.invoke} here, too!
               # Trailblazer::Activity.extend(Pro::Call::Activity) # FIXME: only if allowed! # TODO: only apply to selected OPs.
-            else # no configuration happend, yet.
+            else # no configuration happened, yet.
               Pro.initialize!(api_key: "")
             end
           end

--- a/lib/trailblazer/pro/rails/railtie.rb
+++ b/lib/trailblazer/pro/rails/railtie.rb
@@ -9,6 +9,8 @@ module Trailblazer
         # load session and set Pro::Session.session
         initializer "trailblazer-pro-rails.load_session_and_extend_operation" do
           config.after_initialize do
+            Trailblazer::Operation.extend(Pro::Operation::WTF)  # TODO: only apply to selected OPs or make at least configurable?
+
             config_options = {
               render_wtf: config.trailblazer.pro.render_wtf,
             }


### PR DESCRIPTION
Add support for configuring tracing for all OPs configured via:

Example configuration:
````ruby
# config/environments/development.rb
config.trailblazer.pro.trace_operations = :all
```

Add info about config to README.
Fix typo in comment :wink:

There is a PR in TRB-PRO that matches these changes.
This works - and that's all I can say about it. 